### PR TITLE
Alphabetise CLI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ A curated list of amazingly awesome Elixir libraries, resources, and shiny thing
 
 * [anubis](https://github.com/bennyhallett/anubis) - Command-Line application framework for Elixir.
 * [getopt](https://github.com/jcomellas/getopt) - Command-line options parser for Erlang.
-* [table_rex](https://github.com/djm/table_rex) - Generate configurable ASCII style tables for display.
 * [progress_bar](https://github.com/henrik/progress_bar) - Command-line progress bars and spinners.
+* [table_rex](https://github.com/djm/table_rex) - Generate configurable ASCII style tables for display.
 
 ## Configuration
 *Libraries and tools working with configurations*


### PR DESCRIPTION
CI fails because `P` comes before `T` in the alphabet!
